### PR TITLE
Fixed the bug where you could not bind an action using a ui_select/ui_accept hotkey

### DIFF
--- a/Motor/Basic/mappable-keys/src/options/rebindable_action.gd
+++ b/Motor/Basic/mappable-keys/src/options/rebindable_action.gd
@@ -3,34 +3,34 @@ extends Button
 # Set this string to the name of the action in the InputMap
 export(String) var action
 
-var _editing = false
-
 
 func _ready():
 	_update_button_text(InputMap.get_action_list(action)[0])
-
+	
 
 func _input(input_event: InputEvent) -> void:
-	if _editing and not input_event is InputEventMouseMotion:
-		InputMap.action_erase_events(action)
-		InputMap.action_add_event(action, input_event)
-		
-		_update_button_text(input_event)
-		_editing = false
-		pressed = false
+	if pressed and not input_event is InputEventMouseMotion:
+		if not input_event.is_pressed():
+			pressed = false
+			release_focus()
+			InputMap.action_erase_events(action)
+			InputMap.action_add_event(action, input_event)
+			_update_button_text(input_event)
+			grab_focus()   
 
 
 func _update_button_text(input_event: InputEvent) -> void:
 	if input_event is InputEventMouseButton:
-			if input_event.button_index == BUTTON_LEFT:
-				text = "Mouse Left"
-			elif input_event.button_index == BUTTON_RIGHT:
-				text = "Mouse Right"
-			elif input_event.button_index == BUTTON_MIDDLE:
-				text = "Mouse Middle"
+		if input_event.button_index == BUTTON_LEFT:
+			text = "Mouse Left"
+		elif input_event.button_index == BUTTON_RIGHT:
+			text = "Mouse Right"
+		elif input_event.button_index == BUTTON_MIDDLE:
+			text = "Mouse Middle"
 	else:
 		text = input_event.as_text()
 
 
-func _on_Button_pressed() -> void:
-	_editing = true
+func _on_Button_toggled(button_pressed):
+	if button_pressed:
+		text = "press a key..."

--- a/Motor/Basic/mappable-keys/src/options/rebindable_action.tscn
+++ b/Motor/Basic/mappable-keys/src/options/rebindable_action.tscn
@@ -13,4 +13,4 @@ __meta__ = {
 }
 action = "ui_select"
 
-[connection signal="pressed" from="." to="." method="_on_Button_pressed"]
+[connection signal="toggled" from="." to="." method="_on_Button_toggled"]


### PR DESCRIPTION
The defaults of a Godot project define keys for ui_select and ui_accept (spacebar, enter, ...) which would make the remappable hotkeys behave incorrectly. This PR fixes this.
Also
- cleaned up code, removing the useless _editing variable, using Button's pressed instead. 
- Added a "press a key..." text change while editing the hotkey.
- moved from signal pressed() to toggled() because it makes more sense