### PR TITLE
Fixes warnings

### DIFF
--- a/Motor/Basic/mappable-keys/src/options/rebindable_action.gd
+++ b/Motor/Basic/mappable-keys/src/options/rebindable_action.gd
@@ -35,6 +35,6 @@ func _update_button_text(input_event: InputEvent) -> void:
 	else:
 		text = input_event.as_text()
 
-func _on_toggled(button_pressed):
-	if button_pressed:
+func _on_toggled(button_pressed_state):
+	if button_pressed_state:
 		text = "press a key..."

--- a/Motor/Basic/mappable-keys/src/options/volume_slider.gd
+++ b/Motor/Basic/mappable-keys/src/options/volume_slider.gd
@@ -15,7 +15,7 @@ var _original_bus_volume : float = 1.0
 var _bus_index = 0
 
 func _ready() -> void:
-	if feedback_sound_path != null:
+	if not feedback_sound_path.is_empty():
 		_feedback_sound = get_node(feedback_sound_path)
 	_bus_index = AudioServer.get_bus_index(bus_name)
 	_original_bus_volume = db_to_linear(AudioServer.get_bus_volume_db(_bus_index))


### PR DESCRIPTION
Fixes warnings in the debugger related to a shadowed property and a get_node() call that returns null.